### PR TITLE
Use string to convert unsafe number instead of bigint

### DIFF
--- a/src/bigdecimal.ts
+++ b/src/bigdecimal.ts
@@ -4271,8 +4271,8 @@ interface BigDecimalConstructor {
  * console.log(v.toString()); // 2
  * ```
  *
- * @param n Any value to build a BigDecimal from. Types other than `Number`, `BigInt` and `BigDecimal` will be internally
- * converted to string and parsed.
+ * @param n Any value to build a BigDecimal from. Types other than `Number` (as safe integer), `BigInt` and `BigDecimal`
+ * will be internally converted to string and parsed.
  * @param scale Scale to use, by default 0.
  * @param mc MathContext object which allows you to set precision and rounding mode.
  * @throws RangeError on following situations:
@@ -4281,7 +4281,7 @@ interface BigDecimalConstructor {
  *     * Both a scale and a math context is provided. You can only give one of scale and math context.
  *       Passing `undefined` is same as omitting an argument.
  *     * If value is a double and scale is given.
- * * If value is not a `number`, a `BigInt` or a `BigDecimal`, it will be converted to string.
+ * * If value is not a `safe integer`, a `BigInt` or a `BigDecimal`, it will be converted to string.
  *   An error will be thrown if the string format is invalid.
  * * If value is not a `BigInt` or `number`, and scale is given.
  */

--- a/src/bigdecimal.ts
+++ b/src/bigdecimal.ts
@@ -653,6 +653,7 @@ export class BigDecimal {
      * @param input input string
      * @param offset first character in the string to inspect.
      * @param len number of characters to consider.
+     * @param scale scale value
      * @param mc the context to use.
      * @throws RangeError if `input` is not a valid
      * representation of a `BigDecimal` or the defined subarray
@@ -663,13 +664,14 @@ export class BigDecimal {
         input: string,
         offset: number,
         len: number,
+        scale: number | undefined,
         mc: MathContext = MathContext.UNLIMITED
     ): BigDecimal {
         // This is the primary string to BigDecimal constructor
 
         // Use locals for all fields values until completion
         let prec = 0; // record precision value
-        let scl = 0; // record scale value
+        let scl = scale || 0; // record scale value
         let rs = 0; // the compact value in long
         let rb: BigInt | null = null; // the inflated value in BigInt
 
@@ -957,7 +959,7 @@ export class BigDecimal {
      */
     private static fromDouble(double: number, mc?: MathContext): BigDecimal {
         const strValue = String(double);
-        return BigDecimal.fromString(strValue, 0, strValue.length, mc);
+        return BigDecimal.fromString(strValue, 0, strValue.length, 0, mc);
     }
 
     /**
@@ -1152,12 +1154,12 @@ export class BigDecimal {
                 if (scale !== undefined) {
                     throw new RangeError('You should not give scale when number is a double');
                 }
-
                 return BigDecimal.fromDouble(value, mc);
             }
             if (!(value > Number.MIN_SAFE_INTEGER && value <= Number.MAX_SAFE_INTEGER)) {
-                // Unsafe range, build from bigint
-                return BigDecimal.fromBigInt(BigInt(value), scale, mc);
+                // Unsafe range, build from string
+                value = String(value);
+                return BigDecimal.fromString(value, 0, value.length, scale, mc);
             }
             return BigDecimal.fromInteger(value, scale, mc);
         }
@@ -1172,7 +1174,7 @@ export class BigDecimal {
             throw new RangeError('You should give scale only with BigInts or integers');
         }
         value = String(value);
-        return BigDecimal.fromString(value, 0, value.length, mc);
+        return BigDecimal.fromString(value, 0, value.length, 0, mc);
     }
 
     /**

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -87,7 +87,6 @@ describe('Constructor test', function () {
 
     it('should contruct from an integer and scale', function () {
         const big = Big(123, 5);
-
         big.scale().should.be.eq(5);
         big.precision().should.be.eq(3);
         should.equal(big.intVal, null);
@@ -98,6 +97,12 @@ describe('Constructor test', function () {
         big2.precision().should.be.eq(11);
         should.equal(big2.intVal, null);
         big2.intCompact.should.be.eq(10000000000);
+
+        const big3 = Big(123, -5);
+        big3.scale().should.be.eq(-5);
+        big3.precision().should.be.eq(3);
+        should.equal(big3.intVal, null);
+        big3.intCompact.should.be.eq(123);
     });
 
     it('should contruct from number and math context', function () {
@@ -120,6 +125,12 @@ describe('Constructor test', function () {
         big.precision().should.be.eq(16);
         should.equal(big.intVal, 9007199254740992n);
         big.intCompact.should.be.eq(Number.MIN_SAFE_INTEGER);
+
+        const big2 = Big(Number.MAX_SAFE_INTEGER + 1, -1);
+        big2.scale().should.be.eq(-1);
+        big2.precision().should.be.eq(16);
+        should.equal(big2.intVal, 9007199254740992n);
+        big2.intCompact.should.be.eq(Number.MIN_SAFE_INTEGER);
     });
 
     it('should build from max value', function () {

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -114,12 +114,28 @@ describe('Constructor test', function () {
         big2.intCompact.should.be.eq(10000);
     });
 
-    it('should build from unsafe number', function () {
+    it('should build from unsafe number and scale', function () {
         const big = Big(Number.MAX_SAFE_INTEGER + 1, 1);
         big.scale().should.be.eq(1);
         big.precision().should.be.eq(16);
         should.equal(big.intVal, 9007199254740992n);
         big.intCompact.should.be.eq(Number.MIN_SAFE_INTEGER);
+    });
+
+    it('should build from max value', function () {
+        const big = Big(Number.MAX_VALUE); // 1.7976931348623157e+308
+        big.scale().should.be.eq(-292);
+        big.precision().should.be.eq(17);
+        should.equal(big.intVal, 17976931348623157n);
+        big.intCompact.should.be.eq(Number.MIN_SAFE_INTEGER);
+    });
+
+    it('should build from min value', function () {
+        const big = Big(Number.MIN_VALUE); // 5e-324
+        big.scale().should.be.eq(324);
+        big.precision().should.be.eq(1);
+        should.equal(big.intCompact, 5);
+        should.equal(big.intVal, null);
     });
 
     it('should throw on invalid argument', function () {

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -91,18 +91,21 @@ describe('Constructor test', function () {
         big.precision().should.be.eq(3);
         should.equal(big.intVal, null);
         big.intCompact.should.be.eq(123);
+        big.toPlainString().should.be.eq("0.00123");
 
         const big2 = Big(10000000000, 2);
         big2.scale().should.be.eq(2);
         big2.precision().should.be.eq(11);
         should.equal(big2.intVal, null);
         big2.intCompact.should.be.eq(10000000000);
+        big2.toPlainString().should.be.eq("100000000.00");
 
         const big3 = Big(123, -5);
         big3.scale().should.be.eq(-5);
         big3.precision().should.be.eq(3);
         should.equal(big3.intVal, null);
         big3.intCompact.should.be.eq(123);
+        big3.toPlainString().should.be.eq("12300000");
     });
 
     it('should contruct from number and math context', function () {
@@ -119,18 +122,20 @@ describe('Constructor test', function () {
         big2.intCompact.should.be.eq(10000);
     });
 
-    it('should build from unsafe number and scale', function () {
+    it('should build from unsafe number and scale', function () {       
         const big = Big(Number.MAX_SAFE_INTEGER + 1, 1);
         big.scale().should.be.eq(1);
         big.precision().should.be.eq(16);
         should.equal(big.intVal, 9007199254740992n);
         big.intCompact.should.be.eq(Number.MIN_SAFE_INTEGER);
+        big.toPlainString().should.be.eq("900719925474099.2");
 
         const big2 = Big(Number.MAX_SAFE_INTEGER + 1, -1);
         big2.scale().should.be.eq(-1);
         big2.precision().should.be.eq(16);
         should.equal(big2.intVal, 9007199254740992n);
         big2.intCompact.should.be.eq(Number.MIN_SAFE_INTEGER);
+        big2.toPlainString().should.be.eq("90071992547409920");
     });
 
     it('should build from max value', function () {

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -91,21 +91,21 @@ describe('Constructor test', function () {
         big.precision().should.be.eq(3);
         should.equal(big.intVal, null);
         big.intCompact.should.be.eq(123);
-        big.toPlainString().should.be.eq("0.00123");
+        big.toPlainString().should.be.eq('0.00123');
 
         const big2 = Big(10000000000, 2);
         big2.scale().should.be.eq(2);
         big2.precision().should.be.eq(11);
         should.equal(big2.intVal, null);
         big2.intCompact.should.be.eq(10000000000);
-        big2.toPlainString().should.be.eq("100000000.00");
+        big2.toPlainString().should.be.eq('100000000.00');
 
         const big3 = Big(123, -5);
         big3.scale().should.be.eq(-5);
         big3.precision().should.be.eq(3);
         should.equal(big3.intVal, null);
         big3.intCompact.should.be.eq(123);
-        big3.toPlainString().should.be.eq("12300000");
+        big3.toPlainString().should.be.eq('12300000');
     });
 
     it('should contruct from number and math context', function () {
@@ -122,20 +122,20 @@ describe('Constructor test', function () {
         big2.intCompact.should.be.eq(10000);
     });
 
-    it('should build from unsafe number and scale', function () {       
+    it('should build from unsafe number and scale', function () {
         const big = Big(Number.MAX_SAFE_INTEGER + 1, 1);
         big.scale().should.be.eq(1);
         big.precision().should.be.eq(16);
         should.equal(big.intVal, 9007199254740992n);
         big.intCompact.should.be.eq(Number.MIN_SAFE_INTEGER);
-        big.toPlainString().should.be.eq("900719925474099.2");
+        big.toPlainString().should.be.eq('900719925474099.2');
 
         const big2 = Big(Number.MAX_SAFE_INTEGER + 1, -1);
         big2.scale().should.be.eq(-1);
         big2.precision().should.be.eq(16);
         should.equal(big2.intVal, 9007199254740992n);
         big2.intCompact.should.be.eq(Number.MIN_SAFE_INTEGER);
-        big2.toPlainString().should.be.eq("90071992547409920");
+        big2.toPlainString().should.be.eq('90071992547409920');
     });
 
     it('should build from max value', function () {


### PR DESCRIPTION
First of all thank you for this library. I'm planning to switch to it until nodejs support BigDecimal natively. 
While refactoring, I noticed a small issue when converting large number to BigDecimal.

To give a quick example, `Big(Number.MAX_VALUE)` would give a different value than expected as bigint is not reliable when converting large numbers:
```ts
BigInt(2e80) // will return 200000000000000000053219729416734553074804802362401618196263954906979517832626176n
BigInt(Number.MAX_VALUE) // will return 179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368n
```

For now, I am mitigating the problem by relying on strings for our largest values.
