### PR TITLE
Allow any value in methods expecting a bigdecimal

### DIFF
--- a/src/bigdecimal.ts
+++ b/src/bigdecimal.ts
@@ -1138,7 +1138,7 @@ export class BigDecimal {
     }
 
     /** @internal */
-    static fromValue(value: any, scale?: number, mc?: MathContext): BigDecimal {
+    static fromValue(value: BigDecimal | BigInt | number | string, scale?: number, mc?: MathContext): BigDecimal {
         if (typeof value === 'number') {
             if (value > Number.MAX_VALUE || value < -Number.MAX_VALUE) {
                 throw new RangeError('Number must be in the range [-Number.MAX_VALUE, Number.MAX_VALUE]');
@@ -1179,7 +1179,7 @@ export class BigDecimal {
      * @param value
      * @internal
      */
-    private static convertToBigDecimal(value: any): BigDecimal {
+    private static convertToBigDecimal(value: BigDecimal | BigInt | number | string): BigDecimal {
         if (value instanceof BigDecimal) return value;
         return BigDecimal.fromValue(value);
     }
@@ -1353,7 +1353,7 @@ export class BigDecimal {
     }
 
     /** @internal */
-    private static checkScale3(intVal: BigInt, val: number) {
+    private static checkScale3(intVal: BigInt, val: number): number {
         if (val > BigDecimal.MAX_INT_VALUE || val < BigDecimal.MIN_INT_VALUE) {
             val = (val > BigDecimal.MAX_INT_VALUE) ? BigDecimal.MAX_INT_VALUE : BigDecimal.MIN_INT_VALUE;
             if (intVal !== BigDecimal.zeroBigInt) {
@@ -1426,7 +1426,7 @@ export class BigDecimal {
     }
 
     /** @internal */
-    private static bigMultiplyPowerTen3(value: BigInt, n: any): BigInt {
+    private static bigMultiplyPowerTen3(value: BigInt, n: number): BigInt {
         if (n <= 0) return value;
         if (n < BigDecimal.TEN_POWERS_TABLE.length) {
             return value!.valueOf() * BigInt(BigDecimal.TEN_POWERS_TABLE[n]);
@@ -1741,7 +1741,7 @@ export class BigDecimal {
      * @param mc the context to use.
      * @return `this + augend`, rounded as necessary.
      */
-    add(augend: any, mc?: MathContext): BigDecimal {
+    add(augend: BigDecimal | BigInt | number | string, mc?: MathContext): BigDecimal {
         augend = BigDecimal.convertToBigDecimal(augend);
         if (!mc || (mc && mc.precision === 0)) {
             if (this.intCompact !== BigDecimal.INFLATED) {
@@ -1809,7 +1809,7 @@ export class BigDecimal {
      * @param mc the context to use.
      * @return `this - subtrahend`, rounded as necessary.
      */
-    subtract(subtrahend: any, mc?: MathContext): BigDecimal {
+    subtract(subtrahend: BigDecimal | BigInt | number | string, mc?: MathContext): BigDecimal {
         subtrahend = BigDecimal.convertToBigDecimal(subtrahend);
         if (!mc || (mc && mc.precision === 0)) {
             if (this.intCompact !== BigDecimal.INFLATED) {
@@ -1847,7 +1847,7 @@ export class BigDecimal {
      * @param mc the context to use.
      * @return `this * multiplicand`, rounded as necessary.
      */
-    multiply(multiplicand: any, mc?: MathContext): BigDecimal {
+    multiply(multiplicand: BigDecimal | BigInt | number | string, mc?: MathContext): BigDecimal {
         multiplicand = BigDecimal.convertToBigDecimal(multiplicand);
         if (!mc || (mc && mc.precision === 0)) {
             const productScale = this.checkScale(this._scale + multiplicand._scale);
@@ -1899,7 +1899,7 @@ export class BigDecimal {
      *   of the division exactly.
      * * If scale is given but rounding mode is not given.
      */
-    divide(divisor: any, scale?: number, roundingMode?: RoundingMode): BigDecimal {
+    divide(divisor: BigDecimal | BigInt | number | string, scale?: number, roundingMode?: RoundingMode): BigDecimal {
         divisor = BigDecimal.convertToBigDecimal(divisor);
         /*
          * Handle zero cases first.
@@ -2002,7 +2002,7 @@ export class BigDecimal {
      *         terminating decimal expansion, including dividing by zero
      * @return `this / divisor`
      */
-    divideWithMathContext(divisor: any, mc?: MathContext): BigDecimal {
+    divideWithMathContext(divisor: BigDecimal | BigInt | number | string, mc?: MathContext): BigDecimal {
         divisor = BigDecimal.convertToBigDecimal(divisor);
         if (divisor.signum() === 0) { // x/0
             if (this.signum() === 0) // 0/0
@@ -2324,7 +2324,7 @@ export class BigDecimal {
      * @throws RangeError if `mc.precision > 0` and the result
      *         requires a precision of more than `mc.precision` digits.
      */
-    divideToIntegralValue(divisor: any, mc?: MathContext): BigDecimal {
+    divideToIntegralValue(divisor: BigDecimal | BigInt | number | string, mc?: MathContext): BigDecimal {
         divisor = BigDecimal.convertToBigDecimal(divisor);
         if (!mc || (mc && (mc.precision === 0 || this.compareMagnitude(divisor) < 0))) {
             // Calculate preferred scale
@@ -2426,7 +2426,7 @@ export class BigDecimal {
      *         require a precision of more than `mc.precision` digits.
      * @see    {@link divideToIntegralValue}
      */
-    remainder(divisor: any, mc?: MathContext): BigDecimal {
+    remainder(divisor: BigDecimal | BigInt | number | string, mc?: MathContext): BigDecimal {
         return this.divideAndRemainder(divisor, mc)[1];
     }
 
@@ -2547,7 +2547,7 @@ export class BigDecimal {
      * @see    {@link divideToIntegralValue}
      * @see    {@link remainder}
      */
-    divideAndRemainder(divisor: any, mc?: MathContext): [BigDecimal, BigDecimal] {
+    divideAndRemainder(divisor: BigDecimal | BigInt | number | string, mc?: MathContext): [BigDecimal, BigDecimal] {
         divisor = BigDecimal.convertToBigDecimal(divisor);
         const result = new Array<BigDecimal>(2);
 
@@ -2931,7 +2931,7 @@ export class BigDecimal {
      * @return -1, 0, or 1 as this `BigDecimal` is numerically
      *          less than, equal to, or greater than `val`.
      */
-    compareTo(val: any): number {
+    compareTo(val: BigDecimal | BigInt | number | string): number {
         val = BigDecimal.convertToBigDecimal(val);
         // Quick path for equal scale and non-inflated case.
         if (this._scale === val._scale) {
@@ -4245,9 +4245,9 @@ export class BigDecimal {
 }
 
 interface BigDecimalConstructor {
-    (n: any, scale?: number, mc?: MathContext): BigDecimal;
+    (n: BigDecimal | BigInt | number | string, scale?: number, mc?: MathContext): BigDecimal;
 
-    new(n: any, scale?: number, mc?: MathContext): BigDecimal;
+    new(n: BigDecimal | BigInt | number | string, scale?: number, mc?: MathContext): BigDecimal;
 }
 
 /**
@@ -4258,6 +4258,7 @@ interface BigDecimalConstructor {
  * Big(123n); // bigint, 123
  * Big(123n, 3); // bigint and scale, 0.123
  * Big(123n, 3, MC(2, RoundingMode.HALF_UP)); // bigint, scale and mc, 0.12
+ * Big(aBigDecimal) // Copies the BigDecimal passed. "scale" and "mc" arguments will not used.
  * Big(123n, undefined, MC(2, RoundingMode.HALF_UP)); // bigint and mc, 1.2E+2
  * Big('1.13e12'); // string, 1.13E+12
  * Big('1.11e11', undefined, MC(2, RoundingMode.HALF_UP)); // string and mc, 1.1E+11
@@ -4300,7 +4301,11 @@ interface BigDecimalConstructor {
  *   An error will be thrown if the string format is invalid.
  * * If value is not a `BigInt` or `number`, and scale is given.
  */
-export const Big = <BigDecimalConstructor> function _Big(n: any, scale?: number, mc?: MathContext): BigDecimal {
+export const Big = <BigDecimalConstructor> function _Big(
+    n: BigDecimal | BigInt | number | string,
+    scale?: number,
+    mc?: MathContext
+): BigDecimal {
     return BigDecimal.fromValue(n, scale, mc);
 };
 

--- a/src/bigdecimal.ts
+++ b/src/bigdecimal.ts
@@ -1167,7 +1167,6 @@ export class BigDecimal {
         if (value instanceof BigDecimal) {
             return new BigDecimal(value.intVal, value.intCompact, value.scale(), value._precision);
         }
-
         if (scale !== undefined) {
             throw new RangeError('You should give scale only with BigInts or integers');
         }
@@ -1736,11 +1735,13 @@ export class BigDecimal {
      * If either number is zero and the precision setting is nonzero then
      * the other number, rounded if necessary, is used as the result.
      *
-     * @param  augend value to be added to this `BigDecimal`.
-     * @param  mc the context to use.
+     * @param augend value to be added to this `BigDecimal`. This value will
+     * be converted to a `BigDecimal` before the operation.
+     * See the {@link Big | constructor} to learn more about the conversion.
+     * @param mc the context to use.
      * @return `this + augend`, rounded as necessary.
      */
-    add(augend: BigDecimal, mc?: MathContext): BigDecimal {
+    add(augend: any, mc?: MathContext): BigDecimal {
         augend = BigDecimal.convertToBigDecimal(augend);
         if (!mc || (mc && mc.precision === 0)) {
             if (this.intCompact !== BigDecimal.INFLATED) {
@@ -1802,11 +1803,13 @@ export class BigDecimal {
      * If `subtrahend` is zero then this, rounded if necessary, is used as the
      * result.  If this is zero then the result is `subtrahend.negate(mc)`.
      *
-     * @param  subtrahend value to be subtracted from this `BigDecimal`.
-     * @param  mc the context to use.
+     * @param subtrahend value to be subtracted from this `BigDecimal`. This value
+     * will be converted to a `BigDecimal` before the operation.
+     * See the {@link Big | constructor} to learn more about the conversion.
+     * @param mc the context to use.
      * @return `this - subtrahend`, rounded as necessary.
      */
-    subtract(subtrahend: BigDecimal, mc?: MathContext): BigDecimal {
+    subtract(subtrahend: any, mc?: MathContext): BigDecimal {
         subtrahend = BigDecimal.convertToBigDecimal(subtrahend);
         if (!mc || (mc && mc.precision === 0)) {
             if (this.intCompact !== BigDecimal.INFLATED) {
@@ -1838,11 +1841,13 @@ export class BigDecimal {
      * Returns a `BigDecimal` whose value is <code>(this &times;
      * multiplicand)</code>, with rounding according to the context settings.
      *
-     * @param  multiplicand value to be multiplied by this `BigDecimal`.
-     * @param  mc the context to use.
+     * @param multiplicand value to be multiplied by this `BigDecimal`. This
+     * value will be converted to a `BigDecimal` before the operation.
+     * See the {@link Big | constructor} to learn more about the conversion.
+     * @param mc the context to use.
      * @return `this * multiplicand`, rounded as necessary.
      */
-    multiply(multiplicand: BigDecimal, mc?: MathContext): BigDecimal {
+    multiply(multiplicand: any, mc?: MathContext): BigDecimal {
         multiplicand = BigDecimal.convertToBigDecimal(multiplicand);
         if (!mc || (mc && mc.precision === 0)) {
             const productScale = this.checkScale(this._scale + multiplicand._scale);
@@ -1986,13 +1991,15 @@ export class BigDecimal {
      * Returns a `BigDecimal` whose value is `(this /
      * divisor)`, with rounding according to the context settings.
      *
-     * @param  divisor value by which this `BigDecimal` is to be
-     * @param  mc the context to use.
+     * @param divisor value by which this `BigDecimal` is to be divided.
+     * This value will be converted to a `BigDecimal` before the operation.
+     * See the {@link Big | constructor} to learn more about the conversion.
+     * @param mc the context to use.
      * @throws RangeError if the exact quotient does not have a
      *         terminating decimal expansion, including dividing by zero
      * @return `this / divisor`
      */
-    divideWithMathContext(divisor: BigDecimal, mc?: MathContext): BigDecimal {
+    divideWithMathContext(divisor: any, mc?: MathContext): BigDecimal {
         divisor = BigDecimal.convertToBigDecimal(divisor);
         if (divisor.signum() === 0) { // x/0
             if (this.signum() === 0) // 0/0
@@ -2305,14 +2312,16 @@ export class BigDecimal {
      * the exact quotient needs more than `mc.precision`
      * digits.
      *
-     * @param  divisor value by which this `BigDecimal` is to be divided.
-     * @param  mc the context to use.
+     * @param divisor value by which this `BigDecimal` is to be divided.
+     * This value will be converted to a `BigDecimal` before the operation.
+     * See the {@link Big | constructor} to learn more about the conversion.
+     * @param mc the context to use.
      * @return The integer part of `this / divisor`.
      * @throws RangeError if divisor is 0
      * @throws RangeError if `mc.precision > 0` and the result
      *         requires a precision of more than `mc.precision` digits.
      */
-    divideToIntegralValue(divisor: BigDecimal, mc?: MathContext): BigDecimal {
+    divideToIntegralValue(divisor: any, mc?: MathContext): BigDecimal {
         divisor = BigDecimal.convertToBigDecimal(divisor);
         if (!mc || (mc && (mc.precision === 0 || this.compareMagnitude(divisor) < 0))) {
             // Calculate preferred scale
@@ -2518,7 +2527,9 @@ export class BigDecimal {
      * separately because the division need only be carried out once.
      *
      * @param  divisor value by which this `BigDecimal` is to be divided,
-     *         and the remainder computed.
+     *         and the remainder computed. This value will be converted to a
+     *         `BigDecimal` before the operation. See the
+     *         {@link Big | constructor} to learn more about the conversion.
      * @param  mc the context to use.
      * @return a two element `BigDecimal` array: the quotient
      *         (the result of `divideToIntegralValue`) is the
@@ -2531,7 +2542,7 @@ export class BigDecimal {
      * @see    {@link divideToIntegralValue}
      * @see    {@link remainder}
      */
-    divideAndRemainder(divisor: BigDecimal, mc?: MathContext): [BigDecimal, BigDecimal] {
+    divideAndRemainder(divisor: any, mc?: MathContext): [BigDecimal, BigDecimal] {
         divisor = BigDecimal.convertToBigDecimal(divisor);
         const result = new Array<BigDecimal>(2);
 
@@ -2909,12 +2920,13 @@ export class BigDecimal {
      * (x.compareTo(y) &lt;<i>op</i>&gt; 0), where
      * &lt;<i>op</i>&gt; is one of the six comparison operators.
 
-     * @param  val `BigDecimal` to which this `BigDecimal` is
-     *         to be compared.
+     * @param val value to which this `BigDecimal` is to be compared.
+     * This value will be converted to a `BigDecimal` before the operation.
+     * See the {@link Big | constructor} to learn more about the conversion.
      * @return -1, 0, or 1 as this `BigDecimal` is numerically
      *          less than, equal to, or greater than `val`.
      */
-    compareTo(val: BigDecimal): number {
+    compareTo(val: any): number {
         val = BigDecimal.convertToBigDecimal(val);
         // Quick path for equal scale and non-inflated case.
         if (this._scale === val._scale) {

--- a/src/bigdecimal.ts
+++ b/src/bigdecimal.ts
@@ -1888,6 +1888,8 @@ export class BigDecimal {
      * specified rounding mode is applied.
      *
      * @param divisor value by which this `BigDecimal` is to be divided.
+     * This value will be converted to a `BigDecimal` before the operation.
+     * See the {@link Big | constructor} to learn more about the conversion.
      * @param scale scale of the `BigDecimal` quotient to be returned.
      * @param roundingMode rounding mode to apply.
      * @return `this / divisor`
@@ -1897,7 +1899,8 @@ export class BigDecimal {
      *   of the division exactly.
      * * If scale is given but rounding mode is not given.
      */
-    divide(divisor: BigDecimal, scale?: number, roundingMode?: RoundingMode): BigDecimal {
+    divide(divisor: any, scale?: number, roundingMode?: RoundingMode): BigDecimal {
+        divisor = BigDecimal.convertToBigDecimal(divisor);
         /*
          * Handle zero cases first.
          */
@@ -2412,6 +2415,8 @@ export class BigDecimal {
      * operation (the result can be negative).
      *
      * @param divisor value by which this `BigDecimal` is to be divided.
+     * This value will be converted to a `BigDecimal` before the operation.
+     * See the {@link Big | constructor} to learn more about the conversion.
      * @param mc the context to use.
      * @return `this % divisor`, rounded as necessary.
      * @throws RangeError if divisor is 0
@@ -2421,7 +2426,7 @@ export class BigDecimal {
      *         require a precision of more than `mc.precision` digits.
      * @see    {@link divideToIntegralValue}
      */
-    remainder(divisor: BigDecimal, mc?: MathContext): BigDecimal {
+    remainder(divisor: any, mc?: MathContext): BigDecimal {
         return this.divideAndRemainder(divisor, mc)[1];
     }
 

--- a/src/bigdecimal.ts
+++ b/src/bigdecimal.ts
@@ -1887,9 +1887,9 @@ export class BigDecimal {
      * be performed to generate a result with the specified scale, the
      * specified rounding mode is applied.
      *
-     * @param  divisor value by which this `BigDecimal` is to be divided.
-     * @param  scale scale of the `BigDecimal` quotient to be returned.
-     * @param  roundingMode rounding mode to apply.
+     * @param divisor value by which this `BigDecimal` is to be divided.
+     * @param scale scale of the `BigDecimal` quotient to be returned.
+     * @param roundingMode rounding mode to apply.
      * @return `this / divisor`
      * @throws RangeError
      * * If `divisor` is zero
@@ -2411,8 +2411,8 @@ export class BigDecimal {
      * mc).multiply(divisor))`.  Note that this is not the modulo
      * operation (the result can be negative).
      *
-     * @param  divisor value by which this `BigDecimal` is to be divided.
-     * @param  mc the context to use.
+     * @param divisor value by which this `BigDecimal` is to be divided.
+     * @param mc the context to use.
      * @return `this % divisor`, rounded as necessary.
      * @throws RangeError if divisor is 0
      * @throws RangeError if the result is inexact but the
@@ -2489,7 +2489,7 @@ export class BigDecimal {
      * substitutable for each other under some arithmetic operations
      * are the two expressions:
      *
-     * @param  value to which this `BigDecimal` is
+     * @param value to which this `BigDecimal` is
      *         to be compared.
      * @return true if and only if the specified value is a
      *         BigDecimal whose value and scale are equal to this
@@ -2526,11 +2526,11 @@ export class BigDecimal {
      * `divideToIntegralValue` and `remainder` methods
      * separately because the division need only be carried out once.
      *
-     * @param  divisor value by which this `BigDecimal` is to be divided,
+     * @param divisor value by which this `BigDecimal` is to be divided,
      *         and the remainder computed. This value will be converted to a
      *         `BigDecimal` before the operation. See the
      *         {@link Big | constructor} to learn more about the conversion.
-     * @param  mc the context to use.
+     * @param mc the context to use.
      * @return a two element `BigDecimal` array: the quotient
      *         (the result of `divideToIntegralValue`) is the
      *         initial element and the remainder is the final element.
@@ -3008,8 +3008,8 @@ export class BigDecimal {
      * division.
      *
      *
-     * @param  newScale scale of the `BigDecimal` value to be returned.
-     * @param  roundingMode The rounding mode to apply. By default it is set to `UNNECESSARY`.
+     * @param newScale scale of the `BigDecimal` value to be returned.
+     * @param roundingMode The rounding mode to apply. By default it is set to `UNNECESSARY`.
      * @return a `BigDecimal` whose scale is the specified value,
      *         and whose unscaled value is determined by multiplying or
      *         dividing this `BigDecimal`'s unscaled value by the
@@ -3128,8 +3128,8 @@ export class BigDecimal {
      *     * The final value from either the positive or negative case
      *   is then rounded to the destination precision.
      *
-     * @param  n power to raise this `BigDecimal` to.
-     * @param  mc the context to use.
+     * @param n power to raise this `BigDecimal` to.
+     * @param mc the context to use.
      * @return <code>this<sup>n</sup></code> using the ANSI standard X3.274-1996
      *         algorithm
      * @throws RangeError if the result is inexact but the
@@ -3484,7 +3484,7 @@ export class BigDecimal {
      * 10<sup>-n</sup>)</code> and scale `max(this.scale()+n,
      * 0)`.
      *
-     * @param  n number of places to move the decimal point to the left.
+     * @param n number of places to move the decimal point to the left.
      * @return a `BigDecimal` which is equivalent to this one with the
      *         decimal point moved `n` places to the left.
      * @throws RangeError if scale overflows.
@@ -3507,7 +3507,7 @@ export class BigDecimal {
      * `BigDecimal` returned by this call has value <code>(this
      * &times; 10<sup>n</sup>)</code> and scale `max(this.scale()-n, 0)`.
      *
-     * @param  n number of places to move the decimal point to the right.
+     * @param n number of places to move the decimal point to the right.
      * @return a `BigDecimal` which is equivalent to this one
      *         with the decimal point moved `n` places to the right.
      * @throws RangeError if scale overflows.
@@ -3524,7 +3524,7 @@ export class BigDecimal {
     /**
      * Returns the minimum of this `BigDecimal` and `val`.
      *
-     * @param  val value with which the minimum is to be computed.
+     * @param val value with which the minimum is to be computed.
      * @return the `BigDecimal` whose value is the lesser of this
      *         `BigDecimal` and `val`.  If they are equal,
      *         as defined by the {@link compareTo}
@@ -3538,7 +3538,7 @@ export class BigDecimal {
     /**
      * Returns the maximum of this `BigDecimal` and `val`.
      *
-     * @param  val value with which the maximum is to be computed.
+     * @param val value with which the maximum is to be computed.
      * @return the `BigDecimal` whose value is the greater of this
      *         `BigDecimal` and `val`.  If they are equal,
      *         as defined by the {@link compareTo}


### PR DESCRIPTION
Additionally "divide" and "remainder" methods are changed to accept "any". "max" and "min" methods are not changed because the return type of them is a "BigDecimal" and they return either the max or min of two BigDecimals. I think it is better to keep their argument types as BigDecimal. Otherwise the following conversion would happen:

```js
const b = Big(2)
const c =  b.max(3)
// c is Big(3)
```

which I think may not be nice.

fixes #80 