### PR TITLE
Handle Symbol.toPrimitive in the BigDecimal class

### DIFF
--- a/src/bigdecimal.ts
+++ b/src/bigdecimal.ts
@@ -4350,6 +4350,36 @@ export class BigDecimal {
             return BigDecimal.divideAndRound3(dividend, scaledDivisor, scale, roundingMode, scale);
         }
     }
+
+    /**
+     * Function called in case BigDecimal is implicitly converted to a primitive value.
+     * The function will throw when the code try to convert the BigDecimal value in the following cases:
+     * - Using a greater or lower comparison operators (>, <, <=, >=)
+     * - Using loose equality operators against number, string, symbol or bigint (==, !=)
+     * - Using an arithmetic operators (+, -, /, *, %, **, --, ++)
+     * - Using bitwise operators (&, |, ^, ~, >>, >>>, <<)
+     *
+     * Note:
+     * - In case of string templates, the function will return the value from {@link toString}.
+     * - It will throw when the plus (+) sign is used for addition or concatenation.
+     * Prefer string template, {@link toString} or {@link add} instead.
+     *
+     * References:
+     * - {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol}
+     * - {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators}
+     * @param hint string
+     * @returns string if hint is `string`
+     * @throws TypeError if hint is `number`
+     * @throws TypeError if hint is `default`
+     */
+    [Symbol.toPrimitive](hint: 'number' | 'string' | 'default') {
+        if (hint === 'number') {
+            throw new TypeError('BigDecimal cannot be implicitly converted to a number type');
+        } else if (hint === 'default') {
+            throw new TypeError('BigDecimal cannot be implicitly converted to an ambiguous type');
+        }
+        return this.toString();
+    }
 }
 
 interface BigDecimalConstructor {

--- a/src/bigdecimal.ts
+++ b/src/bigdecimal.ts
@@ -4373,7 +4373,7 @@ export class BigDecimal {
      * @throws TypeError if hint is `default`
      */
     [Symbol.toPrimitive](hint: 'number' | 'string' | 'default') {
-        if (hint === "string") {
+        if (hint === 'string') {
             return this.toString();
         } else if (hint === 'number') {
             throw new TypeError('BigDecimal cannot be implicitly converted to a number type');

--- a/src/bigdecimal.ts
+++ b/src/bigdecimal.ts
@@ -4373,12 +4373,13 @@ export class BigDecimal {
      * @throws TypeError if hint is `default`
      */
     [Symbol.toPrimitive](hint: 'number' | 'string' | 'default') {
-        if (hint === 'number') {
+        if (hint === "string") {
+            return this.toString();
+        } else if (hint === 'number') {
             throw new TypeError('BigDecimal cannot be implicitly converted to a number type');
-        } else if (hint === 'default') {
+        } else {
             throw new TypeError('BigDecimal cannot be implicitly converted to an ambiguous type');
         }
-        return this.toString();
     }
 }
 

--- a/test/compareTo.js
+++ b/test/compareTo.js
@@ -54,6 +54,8 @@ describe('Compare test', function () {
 
         Object.entries(aliasesMap).forEach(([alias, associatedReturns]) => {
             for (const test of testCases) {
+                const compareToOp = () => Big(test.args[0])[alias](Big(test.args[1]));
+
                 if (test.result === 'errorThrown') {
                     compareToOp.should.throw(
                         undefined,
@@ -63,7 +65,7 @@ describe('Compare test', function () {
                     continue;
                 }
 
-                const actual = Big(test.args[0])[alias](Big(test.args[1]));
+                const actual = compareToOp();
                 const expected = associatedReturns.includes(Number(test.result));
                 actual.should.be.equal(
                     expected,

--- a/test/convertToPrimitive.js
+++ b/test/convertToPrimitive.js
@@ -22,6 +22,7 @@ describe('Convert to primitive test', function () {
     });
 
     it('should perform logical operators on BigDecimal without calling toPrimitive', () => {
+        // toPrimitive is not used in the following cases
         const value = Big(0);
         const testCases = {
             '&&': () => {
@@ -44,6 +45,7 @@ describe('Convert to primitive test', function () {
     });
 
     it('should perform BigDecimal comparison without calling toPrimitive', () => {
+        // toPrimitive is not used in the following cases
         const value = Big(0);
         const testCases = {
             '=== Big': () => {
@@ -89,7 +91,6 @@ describe('Convert to primitive test', function () {
     });
 
     it('should throw when performing BigDecimal comparison with loose equal against primitive values', () => {
-        // toPrimitive is not used for equality operators
         const value = Big(0);
         const testCases = {
             '== 1': () => {

--- a/test/convertToPrimitive.js
+++ b/test/convertToPrimitive.js
@@ -29,7 +29,7 @@ describe('Convert to primitive test', function () {
                 value && 1;
             },
             '||': () => {
-                value || "1";
+                value || '1';
             },
             '!': () => {
                 !value;

--- a/test/convertToPrimitive.js
+++ b/test/convertToPrimitive.js
@@ -1,0 +1,211 @@
+'use strict';
+const { Big } = require('../lib/bigdecimal.js');
+const chai = require('chai');
+chai.should();
+
+/* eslint-disable eqeqeq */
+describe('Convert to primitive test', function () {
+    it('should throw when calling JSON.stringify on BigDecimal', () => {
+        const testCase = () => JSON.stringify(Big(0));
+        testCase.should.throw('Do not know how to serialize a BigInt', undefined, 'expected JSON.stringify to throw');
+    });
+
+    it('should be able to convert to string (hint: string)', () => {
+        const value = Big(0);
+        const testCases = {
+            '`${Big(0)}`': [() => `${value}`, '0'],
+        };
+
+        Object.entries(testCases).forEach(([key, [testCase, expected]]) => {
+            testCase().should.equals(expected, `expected '${key}' to be '${expected}'`);
+        });
+    });
+
+    it('should perform logical operators on BigDecimal without calling toPrimitive', () => {
+        const value = Big(0);
+        const testCases = {
+            '&&': () => {
+                value && 1;
+            },
+            '||': () => {
+                value || "1";
+            },
+            '!': () => {
+                !value;
+            },
+            '??': () => {
+                value ?? Symbol(1);
+            }
+        };
+
+        Object.entries(testCases).forEach(([key, testCase]) => {
+            testCase.should.not.throw(undefined, undefined, `expected '${key}' to not throw`);
+        });
+    });
+
+    it('should perform BigDecimal comparison without calling toPrimitive', () => {
+        const value = Big(0);
+        const testCases = {
+            '=== Big': () => {
+                value === value;
+            },
+            '=== 1': () => {
+                value === 1;
+            },
+            '=== test': () => {
+                value === 'test';
+            },
+            '=== Symbol(1)': () => {
+                value === Symbol(1);
+            },
+            '=== Symbol("test")': () => {
+                value === Symbol('test');
+            },
+            '=== 1n': () => {
+                value === 1n;
+            },
+            '=== true': () => {
+                value === true;
+            },
+
+            // loose equals
+            '== Big': () => {
+                value == value;
+            },
+            '== []': () => {
+                value == [];
+            },
+            '== null': () => {
+                value == null;
+            },
+            '== undefined': () => {
+                value == undefined;
+            }
+        };
+
+        Object.entries(testCases).forEach(([key, testCase]) => {
+            testCase.should.not.throw(undefined, undefined, `expected '${key}' to not throw`);
+        });
+    });
+
+    it('should throw when performing BigDecimal comparison with loose equal against primitive values', () => {
+        // toPrimitive is not used for equality operators
+        const value = Big(0);
+        const testCases = {
+            '== 1': () => {
+                value == 1;
+            },
+            '== test': () => {
+                value == 'test';
+            },
+            '== 1n': () => {
+                value == 1n;
+            },
+            '== true': () => {
+                value == true;
+            },
+            '== Symbol(1)': () => {
+                value == Symbol(1);
+            },
+            '== Symbol("test")': () => {
+                value == Symbol('test');
+            }
+        };
+
+        Object.entries(testCases).forEach(([key, testCase]) => {
+            testCase.should.throw(
+                'BigDecimal cannot be implicitly converted to an ambiguous type',
+                undefined,
+                `expected '${key}' to throw`
+            );
+        });
+    });
+
+    it('should throw when converting to ambiguous type via addition or concatenation', () => {
+        const value = Big(0);
+        const testCases = {
+            'Big(0) + 1': () => value + 1,
+            'prefix + Big(0)': () => 'prefix' + value,
+            'Big(0) + suffix': () => value + 'suffix',
+        };
+
+        Object.entries(testCases).forEach(([key, testCase]) => {
+            testCase.should.throw(
+                'BigDecimal cannot be implicitly converted to an ambiguous type',
+                undefined,
+                `expected '${key}' to throw`
+            );
+        });
+    });
+
+    it('should throw an error when converting to number type', () => {
+        const value = Big(0);
+        const testCases = {
+            'unary +': () => {
+                +value;
+            },
+            '-': () => {
+                value - 1;
+            },
+            '*': () => {
+                value * 1;
+            },
+            '/': () => {
+                value / 1;
+            },
+            '%': () => {
+                value % 1;
+            },
+            '**': () => {
+                value ** 1;
+            },
+            '++': () => {
+                value++;
+            },
+            '--': () => {
+                value--;
+            },
+            '&': () => {
+                value & 1;
+            },
+            '|': () => {
+                value | 1;
+            },
+            '^': () => {
+                value ^ 1;
+            },
+            '~': () => {
+                ~value;
+            },
+            '>': () => {
+                value > 1;
+            },
+            '<': () => {
+                value < 1;
+            },
+            '>=': () => {
+                value >= 1;
+            },
+            '<=': () => {
+                value <= 1;
+            },
+            '>>': () => {
+                value >> 1;
+            },
+            '<<': () => {
+                value << 1;
+            },
+            '>>>': () => {
+                value >>> 1;
+            },
+        };
+
+        Object.entries(testCases).forEach(([key, testCase]) => {
+            testCase.should.throw(
+                'BigDecimal cannot be implicitly converted to a number type',
+                undefined,
+                `expected '${key}' to throw`
+            );
+        });
+    });
+});


### PR DESCRIPTION
Hi!

I wanted to include a small improvement which helped us a lot during our migration to BigDecimal.
To do so, I extended the BigDecimal class to include `Symbol.toPrimitive` in order to mitigate human error by throwing an exception at runtime if a BigDecimal instance is used in arithmetic operations or concatenations (and more, see tests file). 

A few common issues for example: 
- `Big("5") - Big("10.0000000000000005")` => `-5` instead of `-5.0000000000000005`
- `Big("1e-50") > Big("10")` => `true` instead of `false` (due to string comparison)
- `Big(50) + Big(10)` => `"5010"` instead of `60`

I also noticed [a small mistake](5541ccc081f4522778748dd140f0a1d820318699) I made in one of my previous pull request and fixed it here.