### PR TITLE
Fix typings export

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A BigDecimal implementation with native BigInts",
   "exports": {
     "import": "./lib/bigdecimal.mjs",
-    "require": "./lib/bigdecimal.js"
+    "require": "./lib/bigdecimal.js",
+    "typings": "./lib/bigdecimal.d.ts"
   },
   "main": "lib/bigdecimal.js",
   "module": "lib/bigdecimal.mjs",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "exports": {
     "import": "./lib/bigdecimal.mjs",
     "require": "./lib/bigdecimal.js",
-    "typings": "./lib/bigdecimal.d.ts"
+    "types": "./lib/bigdecimal.d.ts"
   },
   "main": "lib/bigdecimal.js",
   "module": "lib/bigdecimal.mjs",


### PR DESCRIPTION
Types are broken in TS with ESM

  There are types at '.../node_modules/bigdecimal.js/lib/bigdecimal.d.ts', but this result could not be resolved when respecting package.json "exports". The 'bigdecimal.js' library may need to update its package.json or typing.

This fixes it

@srknzl 