### PR TITLE
fix: restore Node 10 parsing compatibility

### DIFF
--- a/src/bigdecimal.ts
+++ b/src/bigdecimal.ts
@@ -4305,7 +4305,7 @@ export class BigDecimal {
      * ```
      */
     toFormat(locales?: string | string[], options?: Intl.NumberFormatOptions): string {
-        const style = options?.style;
+        const style = options === undefined ? undefined : options.style;
         const keepAll = style !== 'currency' && style !== 'percent';
         // ponytail: Intl caps maximumFractionDigits at 100; clamp — tiny display loss only beyond 100 dp.
         const defaults = keepAll


### PR DESCRIPTION
## 1. What & Why

Published v1.6.1 declares Node.js >=10.4.0 support, but its CommonJS build contains syntax that Node 10 and 12 cannot parse. This restores the advertised compatibility floor without changing formatting semantics or broadening the build-system scope. A localized legacy-syntax equivalent was chosen over lowering the TypeScript target, which could create unrelated output changes across the package.

## 2. High-Level Impact & Architecture

The public API, package exports, runtime metadata, and `toFormat()` data flow remain unchanged. The only architectural trade-off is intentionally retaining the ES2020 compilation target while ensuring this compatibility-sensitive source path is parseable by older supported runtimes.

## 3. Reviewer Checklist / Risk Areas

- Confirm omitted options and currency/percent style handling remain behaviorally identical.
- Confirm generated CJS contains no optional chaining and loads on Node 10.
- No breaking changes, new dependencies, metadata changes, or generated artifacts are included.
- Validation passed: compile, 134 tests, ESLint, generated-syntax inspection, and packed CJS smoke tests on Node 10.4.1 and 10.24.1.
