### PR TITLE
1.6.2 node 10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ performance premise, so preserve it when touching arithmetic:
 - `_scale: number` (32-bit int range), `_precision: number` (lazy; `0` = not yet computed).
 
 Native `BigInt` does the arbitrary-precision math; there are **no runtime dependencies**.
-Requires Node ≥10.4 or a browser with `BigInt`. Don't add a runtime dep.
+Requires Node ≥18 or a browser with `BigInt`. Don't add a runtime dep.
 
 ## Public API
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ performance premise, so preserve it when touching arithmetic:
 - `_scale: number` (32-bit int range), `_precision: number` (lazy; `0` = not yet computed).
 
 Native `BigInt` does the arbitrary-precision math; there are **no runtime dependencies**.
-Requires Node ≥10.4 or a browser with `BigInt`. Don't add a runtime dep.
+Requires Node ≥18 or a browser with `BigInt`. Don't add a runtime dep.
 
 ## Public API
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ immutability, dual representation).
 
 ## Prerequisites
 
-- **Node.js ≥ 18** (CI runs 18/20/22/24; the library itself supports Node ≥ 10.4).
+- **Node.js ≥ 18** (CI runs 18/20/22/24; the library itself supports Node ≥ 18).
 - **Java (JDK 26)** on your `PATH` — only needed to *regenerate* differential test fixtures.
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![NPM Downloads][downloads-image]][downloads-url]
 [![codecov](https://codecov.io/gh/srknzl/bigdecimal.js/branch/main/graph/badge.svg?token=Y9PL8TFV2L)](https://codecov.io/gh/srknzl/bigdecimal.js)
 
-[BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) based BigDecimal implementation for Node.js 10.4 and above, and for browsers that support native `BigInt` (Chrome 67+, Firefox 68+, Safari 14+).
+[BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) based BigDecimal implementation for Node.js 18 and above, and for browsers that support native `BigInt` (Chrome 67+, Firefox 68+, Safari 14+).
 This implementation is inspired from java BigDecimal class. This implementation is faster than popular big decimal libraries for most operations.
 See [benchmarks results part below](https://github.com/srknzl/bigdecimal.js#benchmark-results) for comparison of each operation.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bigdecimal.js",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bigdecimal.js",
-      "version": "1.6.0",
+      "version": "1.6.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@codemirror/lang-javascript": "^6.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigdecimal.js",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A BigDecimal implementation with native BigInts",
   "exports": {
     "browser": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "url": "https://github.com/srknzl/bigdecimal.js/issues"
   },
   "engines": {
-    "node": ">=10.4.0"
+    "node": ">=18"
   },
   "homepage": "https://srknzl.github.io/bigdecimal.js/",
   "devDependencies": {

--- a/website/guide/installation.md
+++ b/website/guide/installation.md
@@ -1,7 +1,7 @@
 # Installation
 
 BigDecimal.js is pure JavaScript with **zero runtime dependencies** and uses native
-`BigInt`, so it runs anywhere `BigInt` does — Node.js 10.4+ and every modern browser
+`BigInt`, so it runs anywhere `BigInt` does — Node.js 18+ and every modern browser
 (Chrome 67+, Firefox 68+, Safari 14+). No polyfills, no build config.
 
 The package ships CommonJS, ESM, and a minified UMD bundle, with TypeScript declarations


### PR DESCRIPTION
<!-- Thanks for contributing! A short description of the change and why. -->

## Checklist

- [ ] `npm run compile` then `npm test` pass (tests run against compiled `lib/`)
- [ ] `npm run lint` passes
- [ ] Behavior matches Java's `BigDecimal` (the JDK is the spec) — if the change
      affects arithmetic results, the Java-differential fixtures cover it
      (`npm run generate-test-files`, see `util/README.md`)
- [ ] No runtime dependencies added (the zero-dependency guarantee is non-negotiable)
- [ ] Public API changes have JSDoc (it generates the API reference) and a
      `CHANGELOG.md` entry
