### PR TITLE
Split dependabot majors from minor/patch bundling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,20 @@ updates:
     schedule:
       interval: weekly
     groups:
+      # Bundle only non-breaking updates so a single breaking major can't hold
+      # the whole batch hostage (as TS 7 / chai 6 did). Majors arrive as
+      # separate PRs to review and merge one migration at a time.
       dev-dependencies:
         patterns:
           - '*'
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Why

Dependabot's npm group used `patterns: ['*']` with no update-type filter, so **every** dev-dep update — breaking majors included — landed in one all-or-nothing PR. A single unresolvable major (typescript 7 conflicting with typedoc's `≤6.0.x` peer range) turned the whole batch red and unmergeable — see #175, which also carried chai 4→6 (ESM-only, breaks the `require('chai')` test suite), eslint 9→10, and rimraf 5→6.

## Change

- **npm group** now bundles only `minor`/`patch`, so it stays green and mergeable. Majors arrive as **individual PRs**, each reviewable as its own migration.
- **github-actions** now grouped into a single PR instead of the five separate ones this week produced.

Follow-up: the four majors from #175 will re-open individually and can be tackled deliberately (TS 7 is blocked until typedoc supports it; chai 6 needs the tests moved to ESM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)